### PR TITLE
 Set the fedora-message body to the fedmsg "msg" key 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ env:
     - PYTHONWARNINGS=always::DeprecationWarning
 matrix:
   include:
-    - python: "3.4"
-      env: TOXENV=py34
-    - python: "3.5"
-      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+      dist: xenial
+      sudo: required  # Force Travis to use a Ubuntu 16.04 VM that can run 3.7
     - python: "3.6"
       env: TOXENV=docs
     - python: "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,format,py34,py35,py36,docs,licenses
+envlist = lint,format,py36,py37,docs,licenses
 
 [testenv]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
There's also a CI change since Twisted has killed Python 3.4